### PR TITLE
Fix JAABADetect crash when fastcomputepffs=false

### DIFF
--- a/perframe/JAABADetect.m
+++ b/perframe/JAABADetect.m
@@ -136,7 +136,11 @@ allScores = cell(nbehaviors,numel(expdir));
 for ndx = order(:)'
   
   fprintf('Opening project %s...\n',jabfiles{ndx});
-  data.openJabFileNoExps(jabfiles{ndx},false,'sublexiconPFNames',allpffs);
+  if fastcomputepffs && ~isempty(allpffs)
+    data.openJabFileNoExps(jabfiles{ndx},false,'sublexiconPFNames',allpffs);
+  else
+    data.openJabFileNoExps(jabfiles{ndx},false);
+  end
   for expi = 1:numel(expdir)
     if ~forcecompute
       sfn = fullfile(expdir{expi},scorefilenames{ndx});


### PR DESCRIPTION
## Summary

- When `fastcomputepffs=false` (the default), `allpffs` was empty and was unconditionally passed as `sublexiconPFNames` to `openJabFileNoExps`, wiping out `allperframefns`
- This caused `load()` to be called with no arguments in `ComputeWindowDataChunkStatic`, loading `matlab.mat` from the current directory instead of the actual perframe data files, giving a misleading "Unrecognized field name 'data'" error
- Fix: only pass the `sublexiconPFNames` override when `fastcomputepffs=true` and `allpffs` is non-empty; otherwise call `openJabFileNoExps` without the override so the project's full feature list is preserved

## Test plan

- [ ] Run `JAABADetect` without `fastcomputepffs` (default) — should classify without crashing
- [ ] Run `JAABADetect` with `'fastcomputepffs', true` — should classify using only perframe features needed by the classifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)