### PR TITLE
Fix uigetfilehelp/uiputfilehelp for new MATLAB

### DIFF
--- a/misc/uigetfilehelp.m
+++ b/misc/uigetfilehelp.m
@@ -15,6 +15,6 @@ end
 varargout = cell(1,nargout);
 [varargout{:}] = uigetfile(inputs{:});
 
-if ~isnan(hhelp),
+if ishandle(hhelp),
   deletefileinfodialog(hhelp);
 end

--- a/misc/uiputfilehelp.m
+++ b/misc/uiputfilehelp.m
@@ -15,6 +15,6 @@ end
 varargout = cell(1,nargout);
 [varargout{:}] = uiputfile(inputs{:});
 
-if ~isnan(hhelp),
+if ishandle(hhelp),
   deletefileinfodialog(hhelp);
 end


### PR DESCRIPTION
`uigetfilehelp.m` and `uiputfilehelp.m` guarded the cleanup call with
`~isnan(hhelp)`. On current MATLAB the handle returned by
`showfileinfodialog` is a graphics object rather than a numeric handle, so
`isnan()` no longer applies and the dialog cleanup path breaks.

Use `ishandle(hhelp)`, which is the correct test in both the old numeric-handle
and new graphics-object worlds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)