### PR TITLE
Normalize trailing-underscore field names when loading APT .lbl files

### DIFF
--- a/perframe/loadLbl.m
+++ b/perframe/loadLbl.m
@@ -23,6 +23,22 @@ lbl = load(rawLblFile,'-mat');
 warning('on','MATLAB:load:classNotFound');
 warning('on','MATLAB:load:cannotInstantiateLoadedVariable');
 
+% Newer versions of APT save some Labeler properties under the name of their
+% private backing field, which has a trailing underscore (e.g. movieFilesAll_
+% rather than movieFilesAll).  Rename those to the public property names that
+% the rest of JAABA expects, preferring the underscored version when both are
+% present.  This is cheap despite rmfield() returning a new struct: only the
+% small path-list fields are assigned, and copy-on-write means the big fields
+% (labels, movieInfoAll, ...) are shared by reference rather than copied.
+fns = fieldnames(lbl);
+for i = 1:numel(fns)
+  fn = fns{i};
+  if numel(fn)>1 && fn(end)=='_'
+    lbl.(fn(1:end-1)) = lbl.(fn);
+    lbl = rmfield(lbl,fn);
+  end
+end
+
 [success, message, ~] = rmdir(tname,'s');
 if ~success
   error('Could not clear the temp directory %s\n',message);


### PR DESCRIPTION
## Problem

Importing a JAABA project from a recent APT `.lbl` file fails immediately:

```
Unrecognized field name "movieFilesAll".

Error in APTProject_App/APTProject_OpeningFcn (line 677)
      if isempty(apt.movieFilesAll)
```

Newer versions of APT serialize some `Labeler` properties under the name of their *private backing field*, which carries a trailing underscore. A project saved by such a version contains `movieFilesAll_`, `trxFilesAll_`, `movieFilesAllGT_`, and `trxFilesAllGT_`, while all of JAABA's APT import code reads the public names (`movieFilesAll`, `trxFilesAll`, ...).

Fixing only `movieFilesAll` would not have been enough — the import hits `apt.trxFilesAll` a few steps later at `perframe/APTProject.m:334`.

## Fix

`loadLbl()` now renames any trailing-underscore field to its public name right after the `load`, preferring the underscored version when both are present. That function is the single entry point used by both `perframe/APTProject.m:105` and `APTProject_App`, so the normalization covers every downstream consumer.

## Performance

`rmfield()` returns a new struct, so this could in principle have been expensive on projects with large `labels` / `movieInfoAll` fields. It isn't — only the small path-list fields are ever assigned, and copy-on-write shares the big fields by reference. Measured against a struct holding a 1.6 GB numeric field:

```
genuine 1.6GB deep copy : 0.5042 s
rename loop rep 1       : 0.008073 s
rename loop rep 2       : 0.000298 s
rename loop rep 3       : 0.000589 s
```

With three huge sibling fields at once (~3.5 GB total) all four renames take 0.013 s.

## Testing

Verified against the `.lbl` that triggered the report (a 6-movie, single-animal keystone project, APT `VERSION` 3.1):

```
has movieFilesAll_: 0
has movieFilesAll : 1  size [6 1]
    {'.../keystone_lps1_sal/Test 1.mp4'}  ... (6 movies)
trxFilesAll size [6 1]
```

The label struct itself is 0.18 MB; the 891 MB in that file is the `deepnet-20000` checkpoint, and the `untar` in `loadLbl` dominates its runtime by about four orders of magnitude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)